### PR TITLE
Improve synchronous runner and instructions handling

### DIFF
--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -225,10 +225,11 @@ class Agent(Generic[TContext]):
         if isinstance(self.instructions, str):
             return self.instructions
         elif callable(self.instructions):
-            if inspect.iscoroutinefunction(self.instructions):
-                return await cast(Awaitable[str], self.instructions(run_context, self))
-            else:
-                return cast(str, self.instructions(run_context, self))
+            instructions_result = self.instructions(run_context, self)
+            if inspect.isawaitable(instructions_result):
+                return await cast(Awaitable[str | None], instructions_result)
+
+            return cast(str | None, instructions_result)
         elif self.instructions is not None:
             logger.error(f"Instructions must be a string or a function, got {self.instructions}")
 

--- a/src/agents/result.py
+++ b/src/agents/result.py
@@ -153,34 +153,36 @@ class RunResultStreaming(RunResultBase):
         - A MaxTurnsExceeded exception if the agent exceeds the max_turns limit.
         - A GuardrailTripwireTriggered exception if a guardrail is tripped.
         """
-        while True:
-            self._check_errors()
-            if self._stored_exception:
-                logger.debug("Breaking due to stored exception")
-                self.is_complete = True
-                break
-
-            if self.is_complete and self._event_queue.empty():
-                break
-
-            try:
-                item = await self._event_queue.get()
-            except asyncio.CancelledError:
-                break
-
-            if isinstance(item, QueueCompleteSentinel):
-                self._event_queue.task_done()
-                # Check for errors, in case the queue was completed due to an exception
+        try:
+            while True:
                 self._check_errors()
-                break
+                if self._stored_exception:
+                    logger.debug("Breaking due to stored exception")
+                    self.is_complete = True
+                    break
 
-            yield item
-            self._event_queue.task_done()
+                if self.is_complete and self._event_queue.empty():
+                    break
 
-        if self._trace:
-            self._trace.finish(reset_current=True)
+                try:
+                    item = await self._event_queue.get()
+                except asyncio.CancelledError:
+                    break
 
-        await self._cleanup_tasks()
+                if isinstance(item, QueueCompleteSentinel):
+                    self._event_queue.task_done()
+                    # Check for errors, in case the queue was completed due to an exception
+                    self._check_errors()
+                    break
+
+                yield item
+                self._event_queue.task_done()
+        finally:
+            if self._trace:
+                self._trace.finish(reset_current=True)
+                self._trace = None
+
+            await self._cleanup_tasks()
 
         if self._stored_exception:
             raise self._stored_exception
@@ -214,11 +216,12 @@ class RunResultStreaming(RunResultBase):
     async def _cleanup_tasks(self):
         tasks: list[asyncio.Task[Any]] = []
 
-        for task in (
-            self._run_impl_task,
-            self._input_guardrails_task,
-            self._output_guardrails_task,
+        for attr_name in (
+            "_run_impl_task",
+            "_input_guardrails_task",
+            "_output_guardrails_task",
         ):
+            task = getattr(self, attr_name)
             if task is None:
                 continue
 
@@ -227,8 +230,18 @@ class RunResultStreaming(RunResultBase):
 
             tasks.append(task)
 
+            setattr(self, attr_name, None)
+
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def aclose(self) -> None:
+        """Cancel background tasks and finish tracing without consuming the event stream."""
+        if self._trace:
+            self._trace.finish(reset_current=True)
+            self._trace = None
+
+        await self._cleanup_tasks()
 
     def __str__(self) -> str:
         return pretty_print_run_result_streaming(self)

--- a/src/agents/result.py
+++ b/src/agents/result.py
@@ -180,7 +180,7 @@ class RunResultStreaming(RunResultBase):
         if self._trace:
             self._trace.finish(reset_current=True)
 
-        self._cleanup_tasks()
+        await self._cleanup_tasks()
 
         if self._stored_exception:
             raise self._stored_exception
@@ -211,15 +211,24 @@ class RunResultStreaming(RunResultBase):
             if exc and isinstance(exc, Exception):
                 self._stored_exception = exc
 
-    def _cleanup_tasks(self):
-        if self._run_impl_task and not self._run_impl_task.done():
-            self._run_impl_task.cancel()
+    async def _cleanup_tasks(self):
+        tasks: list[asyncio.Task[Any]] = []
 
-        if self._input_guardrails_task and not self._input_guardrails_task.done():
-            self._input_guardrails_task.cancel()
+        for task in (
+            self._run_impl_task,
+            self._input_guardrails_task,
+            self._output_guardrails_task,
+        ):
+            if task is None:
+                continue
 
-        if self._output_guardrails_task and not self._output_guardrails_task.done():
-            self._output_guardrails_task.cancel()
+            if not task.done():
+                task.cancel()
+
+            tasks.append(task)
+
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
 
     def __str__(self) -> str:
         return pretty_print_run_result_streaming(self)

--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -324,7 +324,18 @@ class Runner:
             A run result containing all the inputs, guardrail results and the output of the last
             agent. Agents may perform handoffs, so we don't know the specific type of the output.
         """
-        return asyncio.get_event_loop().run_until_complete(
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            running_loop = None
+
+        if running_loop is not None:
+            raise AgentsException(
+                "Runner.run_sync() cannot be used when an event loop is already running. "
+                "Use Runner.run() instead."
+            )
+
+        return asyncio.run(
             cls.run(
                 starting_agent,
                 input,

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -1,3 +1,5 @@
+import functools
+
 import pytest
 from pydantic import BaseModel
 
@@ -25,6 +27,17 @@ async def test_system_instructions():
 
     agent = agent.clone(instructions=async_instructions)
     assert await agent.get_system_prompt(context) == "async_123"
+
+    partial_async = functools.partial(async_instructions)
+    agent = agent.clone(instructions=partial_async)
+    assert await agent.get_system_prompt(context) == "async_123"
+
+    class AsyncCallable:
+        async def __call__(self, agent: Agent[None], context: RunContextWrapper[None]) -> str:
+            return "callable_123"
+
+    agent = agent.clone(instructions=AsyncCallable())
+    assert await agent.get_system_prompt(context) == "callable_123"
 
 
 @pytest.mark.asyncio

--- a/tests/test_run_result_streaming.py
+++ b/tests/test_run_result_streaming.py
@@ -1,0 +1,97 @@
+import asyncio
+
+import pytest
+
+from agents import Agent
+from agents._run_impl import QueueCompleteSentinel
+from agents.result import RunResultStreaming
+
+
+@pytest.mark.asyncio
+async def test_stream_events_cleans_up_on_close():
+    agent = Agent(name="test")
+    result = RunResultStreaming(
+        input="hi",
+        new_items=[],
+        raw_responses=[],
+        final_output=None,
+        input_guardrail_results=[],
+        output_guardrail_results=[],
+        current_agent=agent,
+        current_turn=0,
+        max_turns=1,
+        _current_agent_output_schema=None,
+        _trace=None,
+    )
+
+    block_event = asyncio.Event()
+    result._run_impl_task = asyncio.create_task(block_event.wait())
+    result._input_guardrails_task = asyncio.create_task(block_event.wait())
+    result._output_guardrails_task = asyncio.create_task(block_event.wait())
+
+    tasks = (
+        result._run_impl_task,
+        result._input_guardrails_task,
+        result._output_guardrails_task,
+    )
+
+    stream = result.stream_events()
+    await stream.aclose()
+
+    assert all(task.cancelled() for task in tasks)
+    assert result._run_impl_task is None
+    assert result._input_guardrails_task is None
+    assert result._output_guardrails_task is None
+
+
+@pytest.mark.asyncio
+async def test_stream_events_raises_stored_exception_after_cleanup():
+    agent = Agent(name="test")
+    result = RunResultStreaming(
+        input="hi",
+        new_items=[],
+        raw_responses=[],
+        final_output=None,
+        input_guardrail_results=[],
+        output_guardrail_results=[],
+        current_agent=agent,
+        current_turn=0,
+        max_turns=1,
+        _current_agent_output_schema=None,
+        _trace=None,
+    )
+
+    await result._event_queue.put(QueueCompleteSentinel())
+    result.is_complete = True
+    result._stored_exception = RuntimeError("boom")
+
+    stream = result.stream_events()
+
+    with pytest.raises(RuntimeError):
+        async for _ in stream:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_run_result_streaming_aclose_without_stream():
+    agent = Agent(name="test")
+    result = RunResultStreaming(
+        input="hi",
+        new_items=[],
+        raw_responses=[],
+        final_output=None,
+        input_guardrail_results=[],
+        output_guardrail_results=[],
+        current_agent=agent,
+        current_turn=0,
+        max_turns=1,
+        _current_agent_output_schema=None,
+        _trace=None,
+    )
+
+    block_event = asyncio.Event()
+    result._run_impl_task = asyncio.create_task(block_event.wait())
+
+    await result.aclose()
+
+    assert result._run_impl_task is None

--- a/tests/test_runner_sync.py
+++ b/tests/test_runner_sync.py
@@ -1,0 +1,31 @@
+import pytest
+
+from agents import Agent, AgentsException, Runner
+
+from .fake_model import FakeModel
+from .test_responses import get_text_message
+
+
+def test_run_sync_uses_asyncio_run_when_no_loop():
+    model = FakeModel()
+    agent = Agent(
+        name="test",
+        model=model,
+    )
+    model.set_next_output([get_text_message("sync_result")])
+
+    result = Runner.run_sync(agent, input="hello")
+
+    assert result.final_output == "sync_result"
+
+
+@pytest.mark.asyncio
+async def test_run_sync_rejected_when_loop_running():
+    model = FakeModel()
+    agent = Agent(
+        name="test",
+        model=model,
+    )
+
+    with pytest.raises(AgentsException):
+        Runner.run_sync(agent, input="hello")


### PR DESCRIPTION
## Summary
- guard Runner.run_sync against existing event loops and delegate to asyncio.run when safe
- allow Agent instructions callables that return awaitables (partials and callable instances)
- ensure streaming run results cancel and await background tasks
- expand test coverage for instruction handling and synchronous runner behavior

## Testing
- make lint *(fails: unable to download dependencies in this environment)*
- make tests *(fails: unable to download dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccd15275648327b883fc08006b7d25